### PR TITLE
Database Persistence & Day Selection Refresh Logic

### DIFF
--- a/packages/Nutrition/src/atoms/day.ts
+++ b/packages/Nutrition/src/atoms/day.ts
@@ -1,5 +1,6 @@
 import { atom } from "jotai";
-import type { CoreDate } from "@/domain";
+import { Day, type CoreDate } from "@/domain";
+import { getDay, addItem, type DayEntries, type AddDiaryItemInput } from "@/services/storage/diary";
 
 /**
  * Macro values for a food entry
@@ -14,30 +15,98 @@ export interface FoodMacros {
     // Add more as needed
 }
 
+// ─────────────────────────────────────────────────────────────
+// Selected Day Atom
+// ─────────────────────────────────────────────────────────────
+
 /**
- * A single food entry logged for the day
+ * The currently selected day for viewing/logging entries.
+ * Defaults to today. Set by WeekDaySelector.
  */
-export interface FoodEntry {
-    id: string;
-    code: string;
-    name: string;
-    time: CoreDate;
-    servingCount: number;
-    servingSize: number;
-    unit: string;
-    macros: FoodMacros;
+export const selectedDayAtom = atom<CoreDate>(Day.today());
+
+/**
+ * Derived atom for the selected day's UUID (for comparison)
+ */
+export const selectedDayUUIDAtom = atom((get) => {
+    return Day.toUUID(get(selectedDayAtom));
+});
+
+// ─────────────────────────────────────────────────────────────
+// Refresh Trigger
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Counter atom to trigger refetching of day entries.
+ * Increment this after adding/removing entries.
+ */
+export const refreshTriggerAtom = atom(0);
+
+/**
+ * Write-only atom to trigger a refresh of day entries
+ */
+export const triggerRefreshAtom = atom(
+    null,
+    (_get, set) => {
+        set(refreshTriggerAtom, (prev) => prev + 1);
+    }
+);
+
+// ─────────────────────────────────────────────────────────────
+// Day Entries Atom (async)
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Async atom that fetches entries for the selected day.
+ * Automatically refetches when selectedDayAtom or refreshTriggerAtom changes.
+ */
+export const dayEntriesAtom = atom(async (get) => {
+    const selectedDay = get(selectedDayAtom);
+    // Subscribe to refresh trigger to enable refetching
+    get(refreshTriggerAtom);
+
+    const entries = await getDay(selectedDay);
+    return entries;
+});
+
+// ─────────────────────────────────────────────────────────────
+// Add Entry Atom
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Input for adding a new diary entry via the atom
+ */
+export interface AddEntryInput {
+    hour: number;
+    entry: AddDiaryItemInput;
 }
 
 /**
- * Atom containing all food entries for the current day
+ * Write-only atom that adds an entry to storage and triggers a refresh.
+ * Uses the currently selected day.
  */
-export const dailyFoodEntriesAtom = atom<FoodEntry[]>([]);
+export const addEntryAndRefreshAtom = atom(
+    null,
+    async (get, set, input: AddEntryInput) => {
+        const selectedDay = get(selectedDayAtom);
+
+        // Persist to storage
+        await addItem(selectedDay, input.hour, input.entry);
+
+        // Trigger refresh to update the UI
+        set(refreshTriggerAtom, (prev) => prev + 1);
+    }
+);
+
+// ─────────────────────────────────────────────────────────────
+// Daily Totals (computed from entries)
+// ─────────────────────────────────────────────────────────────
 
 /**
- * Derived atom that computes the total macros from all entries
+ * Derived atom that computes total macros from the day's entries
  */
-export const dailyTotalsAtom = atom((get) => {
-    const entries = get(dailyFoodEntriesAtom);
+export const dailyTotalsAtom = atom(async (get) => {
+    const entries = await get(dayEntriesAtom);
 
     const totals: FoodMacros = {
         calories: 0,
@@ -48,65 +117,20 @@ export const dailyTotalsAtom = atom((get) => {
         sugars: 0,
     };
 
-    for (const entry of entries) {
-        totals.calories += entry.macros.calories;
-        totals.protein += entry.macros.protein;
-        totals.fat += entry.macros.fat;
-        totals.carbs += entry.macros.carbs;
-        totals.fiber += entry.macros.fiber;
-        totals.sugars += entry.macros.sugars;
+    // Flatten all entries from all hours and sum up
+    for (const hourEntries of Object.values(entries)) {
+        for (const entry of hourEntries) {
+            totals.calories += entry.macros.calories;
+            totals.protein += entry.macros.protein;
+            totals.fat += entry.macros.fat;
+            totals.carbs += entry.macros.carbs;
+            totals.fiber += entry.macros.fiber;
+            totals.sugars += entry.macros.sugars;
+        }
     }
 
     return totals;
 });
 
-/**
- * Input for adding a new food entry
- */
-export interface AddFoodEntryInput {
-    code: string;
-    name: string;
-    time: CoreDate;
-    servingCount: number;
-    servingSize: number;
-    unit: string;
-    macros: FoodMacros;
-}
-
-/**
- * Write-only atom to add a food entry
- */
-export const addFoodEntryAtom = atom(
-    null,
-    (get, set, input: AddFoodEntryInput) => {
-        const entries = get(dailyFoodEntriesAtom);
-        const newEntry: FoodEntry = {
-            id: `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-            ...input,
-        };
-        set(dailyFoodEntriesAtom, [...entries, newEntry]);
-        return newEntry;
-    }
-);
-
-/**
- * Write-only atom to remove a food entry by id
- */
-export const removeFoodEntryAtom = atom(
-    null,
-    (get, set, id: string) => {
-        const entries = get(dailyFoodEntriesAtom);
-        set(dailyFoodEntriesAtom, entries.filter((entry) => entry.id !== id));
-    }
-);
-
-/**
- * Write-only atom to clear all entries for the day
- */
-export const clearDailyEntriesAtom = atom(
-    null,
-    (_get, set) => {
-        set(dailyFoodEntriesAtom, []);
-    }
-);
-
+// Re-export DayEntries type for convenience
+export type { DayEntries };

--- a/packages/Nutrition/src/components/DiaryTracker.tsx
+++ b/packages/Nutrition/src/components/DiaryTracker.tsx
@@ -1,28 +1,17 @@
-import { useEffect, useState } from "react";
-import { useSetAtom } from "jotai";
-import { Day, Time } from "@/domain";
+import { useSetAtom, useAtomValue } from "jotai";
+import { Time } from "@/domain";
 import { Plus } from "@ydin/design-system/icons";
 import { Button, FoodCard } from "@ydin/design-system";
 import { logHourAtom, generateTimeSlots } from "@/atoms/time";
 import { sheetExpandedAtom } from "@/atoms/sheet";
-import { getDay, type DayEntries } from "@/services/storage/diary";
+import { dayEntriesAtom, selectedDayUUIDAtom } from "@/atoms/day";
 
 function DiaryTracker() {
     const timeSlots = generateTimeSlots();
-    const today = Day.today();
-    const todayUUID = Day.toUUID(today);
+    const selectedDayUUID = useAtomValue(selectedDayUUIDAtom);
+    const dayEntries = useAtomValue(dayEntriesAtom);
     const setLogHour = useSetAtom(logHourAtom);
     const setIsExpanded = useSetAtom(sheetExpandedAtom);
-    const [dayEntries, setDayEntries] = useState<DayEntries>({});
-
-    // Fetch entries for today on mount
-    useEffect(() => {
-        async function fetchEntries() {
-            const entries = await getDay(today);
-            setDayEntries(entries);
-        }
-        fetchEntries();
-    }, [todayUUID]);
 
     return (
         <div className="flow-root">
@@ -30,7 +19,7 @@ function DiaryTracker() {
                 {timeSlots.map((timeSlot, idx) => {
                     const label = Time.toLabel(timeSlot);
                     const hour = timeSlot.hours;
-                    const uuid = Time.toUUID(timeSlot, todayUUID);
+                    const uuid = Time.toUUID(timeSlot, selectedDayUUID);
                     return (
                         <li key={uuid}>
                             <div className="relative pb-5">

--- a/packages/Nutrition/src/components/WeekDaySelector.tsx
+++ b/packages/Nutrition/src/components/WeekDaySelector.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useSetAtom, useAtomValue } from "jotai";
 import { DayButton } from "@ydin/design-system";
 import useEmblaCarousel from 'embla-carousel-react'
 import { Day, DateConfig, type CoreDate, type Week } from "@/domain";
+import { selectedDayAtom, selectedDayUUIDAtom } from "@/atoms/day";
 
 function WeekDaySelector() {
     const shouldAppendRef = useRef<string | null>(null);
@@ -14,8 +16,9 @@ function WeekDaySelector() {
         startIndex: 1
     });
 
-    // Initialize state with lazy initializers (run once on mount)
-    const [selectedDateUUID, setSelectedDateUUID] = useState(() => Day.toUUID(Day.today()));
+    // Use the centralized selected day atom
+    const setSelectedDay = useSetAtom(selectedDayAtom);
+    const selectedDayUUID = useAtomValue(selectedDayUUIDAtom);
 
     const [weeks, setWeeks] = useState<Week[]>(() => {
         const thisWeek = Day.getWeek(Day.today());
@@ -87,8 +90,8 @@ function WeekDaySelector() {
                                         key={dayUUID}
                                         day={dayLabel.toUpperCase()}
                                         date={dateNum}
-                                        active={dayUUID === selectedDateUUID}
-                                        onClick={() => setSelectedDateUUID(dayUUID)}
+                                        active={dayUUID === selectedDayUUID}
+                                        onClick={() => setSelectedDay(coreDate)}
                                     />
                                 );
                             })}

--- a/packages/Nutrition/src/views/Tracker.tsx
+++ b/packages/Nutrition/src/views/Tracker.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { useAtomValue } from "jotai";
 import { useParams } from "react-router-dom";
 import WeekDaySelector from "@/components/WeekDaySelector";
@@ -5,6 +6,7 @@ import TopNavigation from "@/components/TopNavigation";
 import DiaryTracker from "@/components/DiaryTracker";
 import MacroProgressBar from "@/components/MacroProgressBar";
 import FoodSearchSheet from "@/components/FoodSearchSheet";
+import { LoadingSpinner } from "@/components/ui";
 import { sheetExpandedAtom } from "@/atoms/sheet";
 
 export default function Tracker() {
@@ -16,7 +18,9 @@ export default function Tracker() {
             <TopNavigation />
             <WeekDaySelector />
             <MacroProgressBar />
-            <DiaryTracker />
+            <Suspense fallback={<div className="flex justify-center py-8"><LoadingSpinner show /></div>}>
+                <DiaryTracker />
+            </Suspense>
             <span className="h-30" />
             <FoodSearchSheet code={code} />
         </div>


### PR DESCRIPTION
This PR adds proper data persistence to the database and implements reactive refresh logic when changing days. Previously, food entries were only stored in memory and selecting a different day had no effect on the displayed entries.

## Changes

### Core State Management Refactor (`atoms/day.ts`)

**New atoms introduced:**
- `selectedDayAtom` - Centralized atom for the currently selected day (defaults to today)
- `selectedDayUUIDAtom` - Derived atom for easy comparison of selected day
- `refreshTriggerAtom` - Counter-based atom to trigger refetching of entries
- `triggerRefreshAtom` - Write-only atom to increment the refresh trigger
- `dayEntriesAtom` - **Async atom** that fetches entries from storage, automatically refetches when `selectedDayAtom` or `refreshTriggerAtom` changes
- `addEntryAndRefreshAtom` - Write-only atom that persists entries to storage and triggers a UI refresh

**Removed:**
- `dailyFoodEntriesAtom` - In-memory only storage (replaced by database-backed `dayEntriesAtom`)
- `FoodEntry` interface - Replaced by `DayEntries` from storage service
- `addFoodEntryAtom` - Replaced by `addEntryAndRefreshAtom` which persists to database
- `removeFoodEntryAtom` - No longer needed
- `clearDailyEntriesAtom` - No longer needed

**Updated:**
- `dailyTotalsAtom` - Now async, computes totals from the database-backed entries

### Component Updates

#### `DiaryTracker.tsx`
- Removed local state (`useState`) and manual fetching (`useEffect`)
- Now uses `dayEntriesAtom` directly for reactive data
- Uses `selectedDayUUIDAtom` for time slot UUID generation
- Cleaner, more declarative component

#### `ProductDetail.tsx`
- Uses `addEntryAndRefreshAtom` instead of manually calling storage + updating atoms
- Removed direct dependency on `Day` domain object and storage service
- Simplified `handleLogFood` handler

#### `WeekDaySelector.tsx`
- Connected to centralized `selectedDayAtom`
- Removed local `selectedDateUUID` state
- Day selection now updates the global atom, triggering automatic refetch in DiaryTracker

#### `Tracker.tsx`
- Added `Suspense` boundary around `DiaryTracker` to handle async atom loading
- Added `LoadingSpinner` fallback for better UX during data fetching

## Architecture

```
┌─────────────────────┐
│  WeekDaySelector    │
│  (sets selectedDay) │
└──────────┬──────────┘
           │ writes to
           ▼
┌─────────────────────┐
│   selectedDayAtom   │◄────────────────────┐
└──────────┬──────────┘                     │
           │ triggers                       │
           ▼                                │
┌─────────────────────┐                     │
│   dayEntriesAtom    │──── fetches from ───┼──► Database
│      (async)        │                     │
└──────────┬──────────┘                     │
           │ displays                       │
           ▼                                │
┌─────────────────────┐                     │
│    DiaryTracker     │                     │
└─────────────────────┘                     │
           │                                │
           │ add entry                      │
           ▼                                │
┌─────────────────────┐                     │
│addEntryAndRefreshAtom├──── persists to ───┘
│                     │
│ (increments trigger)│
└─────────────────────┘
```

## Benefits

1. **Data Persistence** - Entries are now stored in the database and survive app restarts
2. **Day Selection Works** - Changing the selected day now shows that day's entries
3. **Single Source of Truth** - Selected day is managed centrally, eliminating sync issues
4. **Reactive Updates** - Adding an entry automatically refreshes the display
5. **Better Loading UX** - Suspense boundary shows loading state while fetching

## Testing

- [x] Select different days and verify entries change accordingly
- [x] Add a food entry and verify it appears immediately
- [x] Refresh the app and verify entries persist
- [x] Verify loading spinner appears during initial load

## Files Changed

| File | Changes |
|------|---------|
| `atoms/day.ts` | Major refactor - async atoms, refresh logic |
| `components/DiaryTracker.tsx` | Use atoms instead of local state |
| `components/ProductDetail.tsx` | Use new add entry atom |
| `components/WeekDaySelector.tsx` | Connect to central selected day atom |
| `views/Tracker.tsx` | Add Suspense boundary |

